### PR TITLE
Fix - OIDC API individual test fail

### DIFF
--- a/authing/lib/authing.dart
+++ b/authing/lib/authing.dart
@@ -19,11 +19,11 @@ class Authing {
       "https://console.authing.cn/console/get-started/" + Authing.sAppId;
   static Config config = Config();
 
-  static void init(String userPoolId, String appId) {
+  static Future<void> init(String userPoolId, String appId) async {
     sUserPoolId = userPoolId;
     sAppId = appId;
 
-    requestPublicConfig();
+    await requestPublicConfig();
 
     http.get(Uri.parse(
         "https://developer-beta.authing.cn/stats/sdk-trace/?appid=" +
@@ -38,7 +38,7 @@ class Authing {
     sPublicKey = publicKey;
   }
 
-  static void requestPublicConfig() async {
+  static Future<void> requestPublicConfig() async {
     String url = "https://" +
         "console" +
         sHost +

--- a/authing/test/authing_test_auto.dart
+++ b/authing/test/authing_test_auto.dart
@@ -276,7 +276,7 @@ void main() {
   });
 
   test('oidcLoginByAccount', () async {
-    Authing.init("60caaf41da89f1954875cee1", "60caaf41df670b771fd08937");
+    await Authing.init("60caaf41da89f1954875cee1", "60caaf41df670b771fd08937");
 
     var res = await OIDCClient.loginByAccount("test", "111111");
 
@@ -288,7 +288,7 @@ void main() {
   test('oidcLoginByPhoneCode', () async {
     String phone = "+86xxx";
 
-    Authing.init("60caaf41da89f1954875cee1", "60caaf41df670b771fd08937");
+    await Authing.init("60caaf41da89f1954875cee1", "60caaf41df670b771fd08937");
 
     var res = await OIDCClient.loginByPhoneCode(phone, "1234");
     expect(res.code, 200);
@@ -305,7 +305,7 @@ void main() {
   });
 
   test('getNewAccessTokenByRefreshToken', () async {
-    Authing.init("60caaf41da89f1954875cee1", "60caaf41df670b771fd08937");
+    await Authing.init("60caaf41da89f1954875cee1", "60caaf41df670b771fd08937");
 
     var result2 =
         await OIDCClient.getNewAccessTokenByRefreshToken("refreshToken");
@@ -314,7 +314,7 @@ void main() {
   });
 
   test('getUserInfoByAccessToken', () async {
-    Authing.init("60caaf41da89f1954875cee1", "60caaf41df670b771fd08937");
+    await Authing.init("60caaf41da89f1954875cee1", "60caaf41df670b771fd08937");
 
     var result2 = await OIDCClient.getUserInfoByAccessToken("accessToken");
     expect(result2.code, 200);


### PR DESCRIPTION
 Fix - Authing.init() return too early to fetch config completed when running individual oidc api test.

## Description
package:authing_sdk/config.dart                   Config.redirectUris
package:authing_sdk/oidc/oidc_client.dart 45:24   OIDCClient.prepareLogin
package:authing_sdk/oidc/oidc_client.dart 101:46  OIDCClient.loginByAccount
test\authing_test_auto.dart 281:32                main.<fn>
test\authing_test_auto.dart 278:30                main.<fn>

LateInitializationError: Field 'redirectUris' has not been initialized.
